### PR TITLE
Fix TinyMCE not rendering on Filament 4

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -7,8 +7,8 @@
         $textareaID = 'tiny-editor-' . str_replace(['.', '#', '$'], '-', $getId()) . '-' . rand();
     @endphp
 
-    <div wire:ignore x-ignore ax-load
-        ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tinyeditor', 'visualbuilder/filament-tinyeditor') }}"
+    <div wire:ignore x-load
+        x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tinyeditor', 'visualbuilder/filament-tinyeditor') }}"
         x-load-css="[@js(\Filament\Support\Facades\FilamentAsset::getStyleHref('tiny-css', package: 'visualbuilder/filament-tinyeditor'))]"
         x-load-js="[@js(\Filament\Support\Facades\FilamentAsset::getScriptSrc($getLanguageId(), package: 'visualbuilder/filament-tinyeditor'))]"
         x-data="tinyeditor({


### PR DESCRIPTION
## Summary
- replace deprecated `ax-load` directive with Filament 4 `x-load` in Tiny editor view
- drop `x-ignore` so Alpine can initialize the component

## Testing
- `composer install`
- `./vendor/bin/pint resources/views/tiny-editor.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_68a52bc5076c8333a02882fe8644fdb5