### PR TITLE
fix(NB-2593): upgrade TinyMCE constraint to ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.2",
         "filament/filament": "^4.0",
         "spatie/laravel-package-tools": "^1.16",
-        "tinymce/tinymce": "^7.3.0"
+        "tinymce/tinymce": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

Bumps the `tinymce/tinymce` composer constraint from `^7.3.0` to `^8.0` to pick up TinyMCE 8.5.0+, which patches CVE-2025-26791 (XSS) and prototype pollution issues.

## Diff

```
-        "tinymce/tinymce": "^7.3.0"
+        "tinymce/tinymce": "^8.0"
```

## Why this needs human review

TinyMCE 7 → 8 is a major version bump and may include downstream breaking changes for consumers of this package. A human should:

- Review the TinyMCE 8 changelog for any API or behaviour changes that affect this package's editor integration
- Decide whether the change warrants a new package release (and what version — 4.x maintenance line, or a new 5.x major)
- Tag the release after merge (the agent has been instructed not to tag releases autonomously)

## Notes for reviewer

This PR was generated by the dev-agent from YouTrack ticket NB-2593. The agent's previous attempt committed directly to `4.x` and pre-emptively created a `5.0.3` tag — both of which were workflow violations that have since been corrected in the agent prompts. The commit on this branch is the same diff; only the surrounding workflow has been redone correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)